### PR TITLE
Fix `set -e` crash in `show_status` on Bash 4+

### DIFF
--- a/gh-secure
+++ b/gh-secure
@@ -286,7 +286,7 @@ show_status() {
   for i in "${!features[@]}"; do
     if ${checks[$i]}; then
       print_success "${features[$i]}"
-      ((enabled++))
+      enabled=$((enabled + 1))
     else
       print_error "${features[$i]} — not enabled"
     fi


### PR DESCRIPTION
## Problem

`gh secure status` silently exits after the first successful feature check on Bash 4+ (Linux). 

### Root cause

```bash
((enabled++))
```

When `enabled` is `0`, the post-increment expression evaluates to `0` (the old value). Bash's `(( ))` arithmetic command returns **exit code 1** when the expression evaluates to zero. Under `set -e` on Bash 4+, this terminates the script immediately.

This doesn't reproduce on macOS because it ships Bash 3.2, which handles `set -e` with arithmetic expressions differently.

## Fix

Replace with a simple assignment:

```bash
enabled=$((enabled + 1))
```

Variable assignments always return exit code 0, regardless of the computed value.

## Testing

```bash
# Reproduces the bug (Bash 4+):
/opt/homebrew/bin/bash -c 'set -e; n=0; ((n++)); echo "survived"'
# → exits silently

# Fixed version:
/opt/homebrew/bin/bash -c 'set -e; n=0; n=$((n+1)); echo "survived"'
# → prints "survived"
```